### PR TITLE
FIX check if force_cpu exists in estimator before setting it

### DIFF
--- a/himalaya/backend/_utils.py
+++ b/himalaya/backend/_utils.py
@@ -94,7 +94,7 @@ def force_cpu_backend(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         # skip if the object does not force cpu use
-        if not args[0].force_cpu:
+        if not hasattr(args[0], "force_cpu") or not args[0].force_cpu:
             return func(*args, **kwargs)
 
         # set corresponding cpu backend


### PR DESCRIPTION
This is probably an edge case, but I think this change will make the decorator a bit more resilient and improve backward compatibility.

Closes #18 
