### PR TITLE
FIX mkl random search with single alpha and numpy Y

### DIFF
--- a/himalaya/kernel_ridge/_random_search.py
+++ b/himalaya/kernel_ridge/_random_search.py
@@ -112,14 +112,15 @@ def solve_multiple_kernel_ridge_random_search(
     else:
         raise ValueError("Unknown parameter n_iter=%r." % (n_iter, ))
 
-    if isinstance(alphas, numbers.Number) or alphas.ndim == 0:
-        alphas = backend.ones_like(Y, shape=(1, )) * alphas
-
     dtype = Ks.dtype
     gammas = backend.asarray(gammas, dtype=dtype)
     device = getattr(gammas, "device", None)
-    gammas, alphas, Xs = backend.check_arrays(gammas, alphas, Xs)
     Y = backend.asarray(Y, dtype=dtype, device="cpu" if Y_in_cpu else device)
+
+    if isinstance(alphas, numbers.Number) or alphas.ndim == 0:
+        alphas = backend.ones_like(Y, shape=(1, )) * alphas
+
+    gammas, alphas, Xs = backend.check_arrays(gammas, alphas, Xs)
     Ks = backend.asarray(Ks, dtype=dtype,
                          device="cpu" if Ks_in_cpu else device)
 

--- a/himalaya/kernel_ridge/tests/test_random_search_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_random_search_kernel.py
@@ -152,3 +152,17 @@ def _test_solve_multiple_kernel_ridge_random_search(
                                     backend.to_numpy(Y_64[:, tt]))
             c1 = backend.asarray_like(c1, K)
             assert_array_almost_equal(c1, refit_weights[:, tt], decimal=5)
+
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
+def test_solve_multiple_kernel_ridge_random_search_single_alpha_numpy(backend):
+    backend = set_backend(backend)
+    # just a smoke test, so make it minimal
+    Ks, Y, gammas, Xs = _create_dataset(backend)
+    alphas = 1.0
+    # make Y a numpy array
+    Y = backend.to_numpy(Y)
+    results = solve_multiple_kernel_ridge_random_search(
+        Ks, Y, n_iter=gammas, alphas=alphas
+    )
+


### PR DESCRIPTION
If `Y` is a numpy array and a single alpha is passed as a regularization parameter, the current code fails because Y is not yet cast to whatever backend is used.

```python
AttributeError: 'numpy.ndarray' object has no attribute 'device'
> /auto/gbox/mvdoc/github/himalaya/himalaya/backend/torch.py(247)ones_like()
    245         dtype = array.dtype
    246     if device is None:
--> 247         device = array.device
    248     return torch.ones(shape, dtype=dtype, device=device, layout=array.layout)
    249
```

This PR fixes the issue and adds a smol test to make sure it doesn't happen again.