### PR TITLE
FIX update of alphas when local_alpha=False for `solve_multiple_kernel_ridge_random_search`

### DIFF
--- a/himalaya/kernel_ridge/_random_search.py
+++ b/himalaya/kernel_ridge/_random_search.py
@@ -249,7 +249,12 @@ def solve_multiple_kernel_ridge_random_search(
 
         # update best_gammas and best_alphas
         epsilon = np.finfo(_dtype_to_str(dtype)).eps
-        mask = cv_scores_ii > current_best_scores + epsilon
+        if local_alpha:
+            mask = cv_scores_ii > current_best_scores + epsilon
+        else:
+            # update based on score across all targets
+            update = cv_scores_ii.mean() > current_best_scores.mean() + epsilon
+            mask = backend.full_like(cv_scores_ii, fill_value=update, dtype=bool)
         current_best_scores[mask] = cv_scores_ii[mask]
         best_gammas[:, mask] = gamma[:, None]
         best_alphas[mask] = alphas[alphas_argmax[mask]]

--- a/himalaya/kernel_ridge/tests/test_random_search_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_random_search_kernel.py
@@ -13,10 +13,9 @@ from himalaya.scoring import r2_score
 from himalaya.kernel_ridge import solve_multiple_kernel_ridge_random_search
 
 
-def _create_dataset(backend):
+def _create_dataset(backend, n_targets=4):
     n_featuress = (100, 200)
     n_samples = 80
-    n_targets = 4
     n_gammas = 3
 
     Xs = [
@@ -166,3 +165,34 @@ def test_solve_multiple_kernel_ridge_random_search_single_alpha_numpy(backend):
         Ks, Y, n_iter=gammas, alphas=alphas
     )
 
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
+@pytest.mark.parametrize('n_kernels', [1, 2])
+def test_solve_multiple_kernel_ridge_random_search_global_alpha(backend, n_kernels):
+    backend = set_backend(backend)
+    # add more targets to make sure we get some variability
+    Ks, Y, gammas, Xs = _create_dataset(backend, n_targets=20)
+    alphas = backend.asarray_like(backend.logspace(-3, 5, 9), Ks)
+    cv = sklearn.model_selection.check_cv(5)
+
+    deltas, *_, best_alphas = solve_multiple_kernel_ridge_random_search(
+        Ks[:n_kernels],
+        Y,
+        n_iter=50,
+        progress_bar=False,
+        alphas=alphas,
+        cv=cv,
+        local_alpha=False,
+        return_alphas=True
+    )
+    # test that we return a single combination of deltas
+    deltas = backend.to_numpy(deltas)
+    if deltas.ndim == 1:
+        assert np.allclose(deltas[0], deltas)
+    else:
+        for dd in deltas:
+            assert np.allclose(dd[0], dd)
+
+    # test that we return a single alpha
+    best_alphas = backend.to_numpy(best_alphas)
+    assert np.allclose(best_alphas[0], best_alphas)


### PR DESCRIPTION
Without this fix, the targets were still updated individually even though the best alpha was selected based on the cv score averaged across targets.

This PR also adds a test to make sure that if `local_alpha=False`, then we get only a single alpha across all targets.