### PR TITLE
FIX only update batch cv_score on hypergrad model fitting early end

### DIFF
--- a/himalaya/kernel_ridge/_hyper_gradient.py
+++ b/himalaya/kernel_ridge/_hyper_gradient.py
@@ -243,7 +243,7 @@ def solve_multiple_kernel_ridge_hyper_gradient(
             if tol is not None:
                 if backend.max(
                         backend.abs(deltas_old - deltas[:, batch])) < tol:
-                    cv_scores = cv_scores[:(ii + 1) * max_iter_inner_hyper]
+                    cv_scores[it + 1, batch] = cv_scores[it, batch]
                     break
 
         ##########################################


### PR DESCRIPTION
In the previous version of the code, during hyper gradient descent if the change in `deltas` from iteration `i` to `i+1` is small then model fitting for that batch ends early, and `cv_scores` is truncated to be `i+1 x num_targets`. However, if batching is used during model fitting then the `cv_score` truncation causes an error (The entire `num_iters x num_targets` matrix is truncated to `i+1 x num_targets`. This causes indexing issues because other batches may still need the full `num_iters` length matrix).

I changed the code to set `cv_scores[i+1:, batch]` to be `cv_scores[i:, batch]`, since the `batch` `deltas` for iteration `i+1` onwards are not updated, and therefore the `cv_scores` would not change for that batch after iteration `i`.