### PR TITLE
use ravel() instead of flatten() to conserve more memory

### DIFF
--- a/himalaya/validation.py
+++ b/himalaya/validation.py
@@ -263,7 +263,7 @@ def _assert_all_finite(X, force_all_finite, numpy=False, batch_size=2 ** 24):
 
     for start in range(0, np.prod(X.shape), batch_size):
         batch = slice(start, start + batch_size)
-        X_batch = X.flatten()[batch]
+        X_batch = X.ravel()[batch]
 
         if backend.any(backend.isinf(X_batch)):
             raise ValueError(msg)


### PR DESCRIPTION
the two methods achieve the same outcome, while flatten creates a copy of the object and ravel does not. In this case creating a copy is not necessary since the values are read and copied after.

This made a difference in my project :)

Local test cases all passed.