### PR TITLE
[WIP] FIX compatibility with sklearn >= 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 htmlcov/
 build/
 dist/
+.cache
 
 # Documentation build
 doc/_build/

--- a/himalaya/_sklearn_compat.py
+++ b/himalaya/_sklearn_compat.py
@@ -213,8 +213,7 @@ def validate_data(estimator, X, y=None, reset=True, validate_separately=False,
             y_check_params = check_params.copy()
             y_check_params.pop('accept_sparse', None)  # y typically shouldn't be sparse
             # Allow y to have flexible dimensions (1D or 2D)
-            if 'ndim' in y_check_params:
-                y_check_params['ndim'] = [1, 2]
+            y_check_params['ndim'] = [1, 2]  # Always allow flexible y dimensions
             y_validated = check_array(y, **y_check_params)
         else:
             # Use default check_array approach - allow y to be flexible

--- a/himalaya/_sklearn_compat.py
+++ b/himalaya/_sklearn_compat.py
@@ -1,0 +1,290 @@
+"""
+Custom sklearn compatibility layer for Himalaya.
+
+This module provides compatibility across different sklearn versions,
+specifically handling the transition from sklearn < 1.6 to >= 1.6.
+"""
+
+import warnings
+from dataclasses import dataclass, field, fields
+from packaging.version import parse as parse_version
+
+import sklearn
+from sklearn.base import BaseEstimator
+from sklearn.utils.validation import check_is_fitted
+
+# Version detection
+sklearn_version = parse_version(sklearn.__version__)
+SKLEARN_1_6_PLUS = sklearn_version >= parse_version("1.6.0")
+
+# Import version-specific components
+if SKLEARN_1_6_PLUS:
+    try:
+        from sklearn.utils._tags import Tags
+        from sklearn.base import validate_data as sklearn_validate_data
+        _HAS_NEW_TAGS = True
+        _HAS_VALIDATE_DATA = True
+    except ImportError:
+        _HAS_NEW_TAGS = False
+        _HAS_VALIDATE_DATA = False
+else:
+    _HAS_NEW_TAGS = False
+    _HAS_VALIDATE_DATA = False
+
+
+# Custom Tags class with _xfail_checks support
+if _HAS_NEW_TAGS:
+    @dataclass
+    class HimalayaTags(Tags):
+        """Custom Tags class with _xfail_checks support."""
+        _xfail_checks: dict = field(default_factory=dict)
+
+
+
+
+def get_estimator_tags(estimator_type="ridge"):
+    """
+    Get appropriate tags for an estimator, handling sklearn version differences.
+    
+    Parameters
+    ----------
+    estimator_type : str
+        Type of estimator: "ridge", "kernel_ridge", or "lasso".
+        
+    Returns
+    -------
+    tags : Tags or dict
+        Appropriate tags object/dict for the sklearn version.
+    """
+    if _HAS_NEW_TAGS:
+        # sklearn >= 1.6: use dataclass-based tags
+        from sklearn.utils._tags import default_tags, TargetTags, InputTags
+        
+        # Start with default regressor tags
+        tags = default_tags('regressor')
+        
+        # Customize target tags - set required=True
+        target_tags = TargetTags(
+            required=True,
+            one_d_labels=False,
+            two_d_labels=False,
+            positive_only=False,
+            multi_output=True,  # All Himalaya estimators support multi-output
+            single_output=True
+        )
+        tags.target_tags = target_tags
+        
+        # Customize for specific estimator types
+        if estimator_type == "kernel_ridge":
+            # Convert to HimalayaTags to support _xfail_checks
+            himalaya_tags = HimalayaTags(
+                estimator_type=tags.estimator_type,
+                target_tags=tags.target_tags,
+                transformer_tags=tags.transformer_tags,
+                classifier_tags=tags.classifier_tags,
+                regressor_tags=tags.regressor_tags,
+                array_api_support=tags.array_api_support,
+                no_validation=tags.no_validation,
+                non_deterministic=tags.non_deterministic,
+                requires_fit=tags.requires_fit,
+                _skip_test=tags._skip_test,
+                input_tags=tags.input_tags,
+                _xfail_checks={
+                    'check_sample_weights_invariance':
+                    'zero sample_weight is not equivalent to removing samples, '
+                    'because of the cross-validation splits.',
+                }
+            )
+            
+            # Allow sparse input for kernel ridge
+            input_tags = InputTags(
+                one_d_array=False,
+                two_d_array=True,
+                three_d_array=False,
+                sparse=True,  # Enable sparse support
+                categorical=False,
+                string=False,
+                dict=False,
+                positive_only=False,
+                allow_nan=False,
+                pairwise=False
+            )
+            himalaya_tags.input_tags = input_tags
+            tags = himalaya_tags
+            
+        return tags
+    else:
+        # sklearn < 1.6: use dictionary-based tags
+        return {'requires_y': True}
+
+
+def create_sklearn_tags_method(estimator_type="ridge"):
+    """
+    Create appropriate __sklearn_tags__ method for an estimator.
+    
+    Parameters
+    ----------
+    estimator_type : str
+        Type of estimator: "ridge", "kernel_ridge", or "lasso".
+        
+    Returns
+    -------
+    method : callable
+        Method to use as __sklearn_tags__ or None for older sklearn.
+    """
+    if _HAS_NEW_TAGS:
+        def __sklearn_tags__(self):
+            return get_estimator_tags(estimator_type)
+        return __sklearn_tags__
+    else:
+        return None
+
+
+def create_more_tags_method():
+    """
+    Create _more_tags method for sklearn < 1.6.
+    
+    Returns
+    -------
+    method : callable
+        Method to use as _more_tags for older sklearn versions.
+    """
+    def _more_tags(self):
+        return {'requires_y': True}
+    return _more_tags
+
+
+def validate_data(estimator, X, y=None, reset=True, validate_separately=False,
+                  cast_to_ndarray=True, **check_params):
+    """
+    Input validation for estimators compatible with Himalaya's backend system.
+    
+    This function provides sklearn 1.6+ compatible validate_data functionality
+    while working with Himalaya's multi-backend architecture.
+    
+    Parameters
+    ----------
+    estimator : estimator instance
+        The estimator instance.
+    X : array-like
+        The input samples.
+    y : array-like, default=None
+        The target values.
+    reset : bool, default=True
+        Whether to reset the `n_features_in_` attribute.
+    validate_separately : bool, default=False
+        Whether to validate X and y separately.
+    cast_to_ndarray : bool, default=True
+        Whether to cast to ndarray (for backward compatibility).
+    **check_params
+        Additional parameters passed to check_array.
+        
+    Returns
+    -------
+    X_validated : array-like
+        The validated input samples.
+    y_validated : array-like, optional
+        The validated target values (if y is not None).
+    """
+    # Import here to avoid circular imports
+    from .validation import check_array
+    
+    if y is None:
+        # Only validate X
+        X_validated = check_array(X, **check_params)
+        
+        # Set n_features_in_ for sklearn compatibility
+        if reset or not hasattr(estimator, 'n_features_in_'):
+            estimator.n_features_in_ = X_validated.shape[1]
+        elif hasattr(estimator, 'n_features_in_'):
+            # Check feature count consistency
+            if X_validated.shape[1] != estimator.n_features_in_:
+                raise ValueError(
+                    f"X has {X_validated.shape[1]} features, but {estimator.__class__.__name__} "
+                    f"is expecting {estimator.n_features_in_} features as input."
+                )
+        
+        return X_validated
+    
+    else:
+        # Validate both X and y
+        if validate_separately:
+            X_validated = check_array(X, **check_params)
+            y_check_params = check_params.copy()
+            y_check_params.pop('accept_sparse', None)  # y typically shouldn't be sparse
+            # Allow y to have flexible dimensions (1D or 2D)
+            if 'ndim' in y_check_params:
+                y_check_params['ndim'] = [1, 2]
+            y_validated = check_array(y, **y_check_params)
+        else:
+            # Use default check_array approach - allow y to be flexible
+            X_validated = check_array(X, **check_params)
+            y_check_params = check_params.copy()
+            y_check_params.pop('accept_sparse', None)  
+            y_check_params.pop('ndim', None)  # Allow y flexible dimensions
+            y_validated = check_array(y, **y_check_params)
+        
+        # Check consistent number of samples
+        if X_validated.shape[0] != y_validated.shape[0]:
+            raise ValueError(
+                f"X and y have inconsistent numbers of samples: "
+                f"{X_validated.shape[0]} != {y_validated.shape[0]}"
+            )
+        
+        # Set n_features_in_ for sklearn compatibility
+        if reset or not hasattr(estimator, 'n_features_in_'):
+            estimator.n_features_in_ = X_validated.shape[1]
+        elif hasattr(estimator, 'n_features_in_'):
+            # Check feature count consistency  
+            if X_validated.shape[1] != estimator.n_features_in_:
+                raise ValueError(
+                    f"X has {X_validated.shape[1]} features, but {estimator.__class__.__name__} "
+                    f"is expecting {estimator.n_features_in_} features as input."
+                )
+        
+        return X_validated, y_validated
+
+
+def setup_estimator_tags(cls, estimator_type="ridge"):
+    """
+    Setup appropriate tags methods for an estimator class.
+    
+    Parameters
+    ----------
+    cls : class
+        The estimator class to modify.
+    estimator_type : str
+        Type of estimator: "ridge", "kernel_ridge", or "lasso".
+        
+    Returns
+    -------
+    cls : class
+        The modified estimator class.
+    """
+    if _HAS_NEW_TAGS:
+        # Add __sklearn_tags__ method for sklearn >= 1.6
+        tags_method = create_sklearn_tags_method(estimator_type)
+        if tags_method:
+            setattr(cls, '__sklearn_tags__', tags_method)
+    
+    # Always add _more_tags for backward compatibility
+    more_tags_method = create_more_tags_method()
+    setattr(cls, '_more_tags', more_tags_method)
+    
+    return cls
+
+
+# Convenience functions for specific estimator types
+def setup_ridge_tags(cls):
+    """Setup tags for Ridge estimators."""
+    return setup_estimator_tags(cls, "ridge")
+
+
+def setup_kernel_ridge_tags(cls):
+    """Setup tags for KernelRidge estimators."""  
+    return setup_estimator_tags(cls, "kernel_ridge")
+
+
+def setup_lasso_tags(cls):
+    """Setup tags for Lasso estimators."""
+    return setup_estimator_tags(cls, "lasso")

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -251,7 +251,7 @@ class KernelRidge(_BaseKernelRidge):
         Y_hat : array of shape (n_samples,) or (n_samples, n_targets)
             Returns predicted values.
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
         backend = get_backend()
         accept_sparse = False if self.kernel == "precomputed" else ("csr",
                                                                     "csc")
@@ -559,7 +559,7 @@ class _BaseWeightedKernelRidge(_BaseKernelRidge):
             If parameter split is True, the array is of shape
             (n_kernels, n_samples,) or (n_kernels, n_samples, n_targets).
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
 
         ndim = 3 if self.kernels == "precomputed" else 2
         accept_sparse = False if self.kernels == "precomputed" else ("csr",

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -1,14 +1,13 @@
 import warnings
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field, fields
 
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils._tags import Tags
 
 from ..backend import force_cpu_backend, get_backend
 from ..scoring import r2_score, r2_score_split
 from ..validation import _get_string_dtype, check_array, check_cv, issparse
+from .._sklearn_compat import setup_kernel_ridge_tags
 from ._hyper_gradient import MULTIPLE_KERNEL_RIDGE_SOLVERS
 from ._kernels import PAIRWISE_KERNEL_FUNCTIONS, pairwise_kernels
 from ._predictions import (
@@ -20,16 +19,7 @@ from ._random_search import KERNEL_RIDGE_CV_SOLVERS
 from ._solvers import KERNEL_RIDGE_SOLVERS, WEIGHTED_KERNEL_RIDGE_SOLVERS
 
 
-@dataclass
-class MyTagsKR(Tags):
-    require_y: bool = True
-    _xfail_checks: dict = field(default_factory=lambda: {
-        'check_sample_weights_invariance':
-        'zero sample_weight is not equivalent to removing samples, '
-        'because of the cross-validation splits.',
-    })
-
-
+@setup_kernel_ridge_tags
 class _BaseKernelRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
     """Base class for kernel ridge estimators"""
 
@@ -64,24 +54,6 @@ class _BaseKernelRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         return function(**direct_params, **solver_params)
 
-    def _more_tags(self):
-        return {'requires_y': True}
-
-    def __sklearn_tags__(self):
-        tags_orig = super().__sklearn_tags__()
-        as_dict = {
-            field.name: getattr(tags_orig, field.name)
-            for field in fields(tags_orig)
-        }
-        as_dict["input_tags"].sparse = True  # allow sparse input
-        tags = MyTagsKR(**as_dict)
-        tags.requires_y = True
-        tags._xfail_checks = {
-            'check_sample_weights_invariance':
-            'zero sample_weight is not equivalent to removing samples, '
-            'because of the cross-validation splits.',
-        }
-        return tags
 
 
 class KernelRidge(_BaseKernelRidge):
@@ -553,30 +525,6 @@ class KernelRidgeCV(KernelRidge):
 
         return self
 
-    def _more_tags(self):
-        return {
-            '_xfail_checks': {
-                'check_sample_weights_invariance':
-                'zero sample_weight is not equivalent to removing samples, '
-                'because of the cross-validation splits.',
-            }
-        }
-    
-    def __sklearn_tags__(self):
-        tags_orig = super().__sklearn_tags__()
-        as_dict = {
-            field.name: getattr(tags_orig, field.name)
-            for field in fields(tags_orig)
-        }
-        as_dict["input_tags"].sparse = True  # allow sparse input
-        tags = MyTagsKR(**as_dict)
-        tags.requires_y = True
-        tags._xfail_checks = {
-            'check_sample_weights_invariance':
-            'zero sample_weight is not equivalent to removing samples, '
-            'because of the cross-validation splits.',
-        }
-        return tags
 
 
 ###############################################################################
@@ -996,29 +944,7 @@ class MultipleKernelRidgeCV(_BaseWeightedKernelRidge):
 
         return self
 
-    def _more_tags(self):
-        return {
-            '_xfail_checks': {
-                'check_sample_weights_invariance':
-                'zero sample_weight is not equivalent to removing samples, '
-                'because of the cross-validation splits.',
-            }
-        }
 
-    def __sklearn_tags__(self):
-        tags_orig = super().__sklearn_tags__()
-        as_dict = {
-            field.name: getattr(tags_orig, field.name)
-            for field in fields(tags_orig)
-        }
-        as_dict["input_tags"].sparse = True  # allow sparse input
-        tags = MyTagsKR(**as_dict)
-        tags._xfail_checks = {
-            'check_sample_weights_invariance':
-            'zero sample_weight is not equivalent to removing samples, '
-            'because of the cross-validation splits.',
-        }
-        return tags
 
 
 class WeightedKernelRidge(_BaseWeightedKernelRidge):

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -3,18 +3,17 @@ import warnings
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
+from sklearn_compat.utils.validation import validate_data
 
-from himalaya.backend import set_backend
-from himalaya.backend import get_backend
-from himalaya.backend import ALL_BACKENDS
+from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
+from himalaya.kernel_ridge import (
+    KernelRidge,
+    KernelRidgeCV,
+    MultipleKernelRidgeCV,
+    WeightedKernelRidge,
+)
+from himalaya.ridge import Ridge, RidgeCV
 from himalaya.utils import assert_array_almost_equal
-
-from himalaya.ridge import Ridge
-from himalaya.ridge import RidgeCV
-from himalaya.kernel_ridge import KernelRidge
-from himalaya.kernel_ridge import KernelRidgeCV
-from himalaya.kernel_ridge import MultipleKernelRidgeCV
-from himalaya.kernel_ridge import WeightedKernelRidge
 
 
 def _create_dataset(backend):
@@ -564,12 +563,15 @@ class KernelRidge_(KernelRidge):
 
     def predict(self, X):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.validation import check_array
         from himalaya.scoring import r2_score
+        from himalaya.validation import check_array
         backend = get_backend()
+
+        X, y = validate_data(self, X, y, reset=False)
 
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.dual_coef_.ndim)
@@ -595,12 +597,15 @@ class KernelRidgeCV_(KernelRidgeCV):
 
     def predict(self, X):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.validation import check_array
         from himalaya.scoring import r2_score
+        from himalaya.validation import check_array
         backend = get_backend()
+
+        X, y = validate_data(self, X, y, reset=False)
 
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.dual_coef_.ndim)
@@ -627,10 +632,12 @@ class MultipleKernelRidgeCV_(MultipleKernelRidgeCV):
 
     def predict(self, X, split=False):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):
         backend = get_backend()
+        X, y = validate_data(self, X, y, reset=False)
         return backend.to_numpy(super().score(X, y, split=split))
 
 
@@ -651,10 +658,12 @@ class WeightedKernelRidge_(WeightedKernelRidge):
 
     def predict(self, X, split=False):
         backend = get_backend()
+        X = validate_data(X, reset=False)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):
         backend = get_backend()
+        X, y = validate_data(X, y, reset=False)
         return backend.to_numpy(super().score(X, y, split=split))
 
 

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -3,9 +3,12 @@ import warnings
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
-from himalaya._sklearn_compat import validate_data
+from sklearn.utils.validation import check_is_fitted
 
+from himalaya._sklearn_compat import validate_data
 from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
+from himalaya.scoring import r2_score
+from himalaya.validation import check_array, issparse
 from himalaya.kernel_ridge import (
     KernelRidge,
     KernelRidgeCV,
@@ -563,12 +566,13 @@ class KernelRidge_(KernelRidge):
 
     def predict(self, X):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main KernelRidge predict method
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
+        accept_sparse = False if self.kernel == "precomputed" else ("csr", "csc")
+        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse, ndim=2)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.scoring import r2_score
-        from himalaya.validation import check_array
         backend = get_backend()
 
         X, y = validate_data(self, X, y, reset=False, validate_separately=True)
@@ -597,12 +601,13 @@ class KernelRidgeCV_(KernelRidgeCV):
 
     def predict(self, X):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main KernelRidgeCV predict method
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
+        accept_sparse = False if self.kernel == "precomputed" else ("csr", "csc")
+        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse, ndim=2)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.scoring import r2_score
-        from himalaya.validation import check_array
         backend = get_backend()
 
         X, y = validate_data(self, X, y, reset=False, validate_separately=True)
@@ -632,7 +637,11 @@ class MultipleKernelRidgeCV_(MultipleKernelRidgeCV):
 
     def predict(self, X, split=False):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main MultipleKernelRidgeCV predict method
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
+        ndim = 3 if self.kernels == "precomputed" else 2
+        accept_sparse = False if self.kernels == "precomputed" else ("csr", "csc")
+        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse, ndim=ndim)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):
@@ -658,7 +667,11 @@ class WeightedKernelRidge_(WeightedKernelRidge):
 
     def predict(self, X, split=False):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main WeightedKernelRidge predict method
+        check_is_fitted(self, ['dual_coef_', 'dtype_'])
+        ndim = 3 if self.kernels == "precomputed" else 2
+        accept_sparse = False if self.kernels == "precomputed" else ("csr", "csc")
+        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse, ndim=ndim)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -571,7 +571,7 @@ class KernelRidge_(KernelRidge):
         from himalaya.validation import check_array
         backend = get_backend()
 
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
 
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.dual_coef_.ndim)
@@ -605,7 +605,7 @@ class KernelRidgeCV_(KernelRidgeCV):
         from himalaya.validation import check_array
         backend = get_backend()
 
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
 
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.dual_coef_.ndim)
@@ -637,7 +637,7 @@ class MultipleKernelRidgeCV_(MultipleKernelRidgeCV):
 
     def score(self, X, y, split=False):
         backend = get_backend()
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
         return backend.to_numpy(super().score(X, y, split=split))
 
 
@@ -663,7 +663,7 @@ class WeightedKernelRidge_(WeightedKernelRidge):
 
     def score(self, X, y, split=False):
         backend = get_backend()
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
         return backend.to_numpy(super().score(X, y, split=split))
 
 

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -3,7 +3,7 @@ import warnings
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
-from sklearn_compat.utils.validation import validate_data
+from himalaya._sklearn_compat import validate_data
 
 from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
 from himalaya.kernel_ridge import (
@@ -658,12 +658,12 @@ class WeightedKernelRidge_(WeightedKernelRidge):
 
     def predict(self, X, split=False):
         backend = get_backend()
-        X = validate_data(X, reset=False)
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):
         backend = get_backend()
-        X, y = validate_data(X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False)
         return backend.to_numpy(super().score(X, y, split=split))
 
 

--- a/himalaya/lasso/tests/test_sklearn_api_lasso.py
+++ b/himalaya/lasso/tests/test_sklearn_api_lasso.py
@@ -4,6 +4,7 @@ import sklearn.utils.estimator_checks
 from himalaya.backend import set_backend
 from himalaya.backend import get_backend
 from himalaya.backend import ALL_BACKENDS
+from himalaya._sklearn_compat import validate_data
 
 from himalaya.lasso import SparseGroupLassoCV
 
@@ -24,6 +25,7 @@ class SparseGroupLassoCV_(SparseGroupLassoCV):
 
     def predict(self, X):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
@@ -31,6 +33,7 @@ class SparseGroupLassoCV_(SparseGroupLassoCV):
         from himalaya.scoring import r2_score
         backend = get_backend()
 
+        X = validate_data(self, X, reset=False)
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 

--- a/himalaya/ridge/_sklearn_api.py
+++ b/himalaya/ridge/_sklearn_api.py
@@ -163,7 +163,7 @@ class Ridge(_BaseRidge):
         Y_hat : array of shape (n_samples,) or (n_samples, n_targets)
             Returns predicted values.
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ['coef_', 'dtype_'])
         backend = get_backend()
         X = check_array(X, dtype=self.dtype_, ndim=2)
         if X.shape[1] != self.n_features_in_:

--- a/himalaya/ridge/_sklearn_api.py
+++ b/himalaya/ridge/_sklearn_api.py
@@ -1,22 +1,17 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, fields
 
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
-from sklearn_compat.utils._tags import Tags
 
 from ..backend import force_cpu_backend, get_backend
 from ..scoring import r2_score, r2_score_split
 from ..validation import _get_string_dtype, check_array, check_cv
+from .._sklearn_compat import setup_ridge_tags
 from ._random_search import GROUP_RIDGE_SOLVERS, solve_ridge_cv_svd
 from ._solvers import RIDGE_SOLVERS
 
 
-@dataclass
-class MyTags(Tags):
-    require_y: bool = True
-
-
+@setup_ridge_tags
 class _BaseRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
     """Base class for ridge estimators"""
 
@@ -44,18 +39,6 @@ class _BaseRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         return function(**direct_params, **solver_params)
 
-    def _more_tags(self):
-        return {'requires_y': True}
-
-    def __sklearn_tags__(self):
-        tags_orig = super().__sklearn_tags__()
-        as_dict = {
-            field.name: getattr(tags_orig, field.name)
-            for field in fields(tags_orig)
-        }
-        tags = MyTags(**as_dict)
-        tags.requires_y = True
-        return tags
 
 
 class Ridge(_BaseRidge):

--- a/himalaya/ridge/tests/test_sklearn_api_ridge.py
+++ b/himalaya/ridge/tests/test_sklearn_api_ridge.py
@@ -149,7 +149,7 @@ class Ridge_(Ridge):
         from himalaya.validation import check_array
         backend = get_backend()
 
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 
@@ -181,7 +181,7 @@ class RidgeCV_(RidgeCV):
         from himalaya.validation import check_array
         backend = get_backend()
 
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 
@@ -218,7 +218,7 @@ class GroupRidgeCV_(GroupRidgeCV):
 
     def score(self, X, y, split=False):
         backend = get_backend()
-        X, y = validate_data(self, X, y, reset=False)
+        X, y = validate_data(self, X, y, reset=False, validate_separately=True)
         return backend.to_numpy(super().score(X, y, split=split))
 
 

--- a/himalaya/ridge/tests/test_sklearn_api_ridge.py
+++ b/himalaya/ridge/tests/test_sklearn_api_ridge.py
@@ -1,7 +1,7 @@
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
-from sklearn_compat.utils.validation import validate_data
+from himalaya._sklearn_compat import validate_data
 
 from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
 from himalaya.ridge import GroupRidgeCV, Ridge, RidgeCV, solve_group_ridge_random_search

--- a/himalaya/ridge/tests/test_sklearn_api_ridge.py
+++ b/himalaya/ridge/tests/test_sklearn_api_ridge.py
@@ -1,12 +1,14 @@
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
-from himalaya._sklearn_compat import validate_data
+from sklearn.utils.validation import check_is_fitted
 
+from himalaya._sklearn_compat import validate_data
 from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
 from himalaya.ridge import GroupRidgeCV, Ridge, RidgeCV, solve_group_ridge_random_search
 from himalaya.scoring import r2_score
 from himalaya.utils import assert_array_almost_equal
+from himalaya.validation import check_array
 
 
 def _create_dataset(backend):
@@ -141,12 +143,12 @@ class Ridge_(Ridge):
 
     def predict(self, X):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main Ridge predict method
+        check_is_fitted(self, ['coef_', 'dtype_'])
+        X = check_array(X, dtype=self.dtype_, ndim=2)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.scoring import r2_score
-        from himalaya.validation import check_array
         backend = get_backend()
 
         X, y = validate_data(self, X, y, reset=False, validate_separately=True)
@@ -173,12 +175,12 @@ class RidgeCV_(RidgeCV):
 
     def predict(self, X):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main RidgeCV predict method  
+        check_is_fitted(self, ['coef_', 'dtype_'])
+        X = check_array(X, dtype=self.dtype_, ndim=2)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.scoring import r2_score
-        from himalaya.validation import check_array
         backend = get_backend()
 
         X, y = validate_data(self, X, y, reset=False, validate_separately=True)
@@ -213,7 +215,9 @@ class GroupRidgeCV_(GroupRidgeCV):
 
     def predict(self, X, split=False):
         backend = get_backend()
-        X = validate_data(self, X, reset=False)
+        # Use check_array directly like the main GroupRidgeCV predict method
+        check_is_fitted(self, ['coef_', 'dtype_'])
+        X = check_array(X, dtype=self.dtype_, ndim=2) 
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):

--- a/himalaya/ridge/tests/test_sklearn_api_ridge.py
+++ b/himalaya/ridge/tests/test_sklearn_api_ridge.py
@@ -1,17 +1,12 @@
-from himalaya.scoring import r2_score
 import pytest
 import sklearn.kernel_ridge
 import sklearn.utils.estimator_checks
+from sklearn_compat.utils.validation import validate_data
 
-from himalaya.backend import set_backend
-from himalaya.backend import get_backend
-from himalaya.backend import ALL_BACKENDS
+from himalaya.backend import ALL_BACKENDS, get_backend, set_backend
+from himalaya.ridge import GroupRidgeCV, Ridge, RidgeCV, solve_group_ridge_random_search
+from himalaya.scoring import r2_score
 from himalaya.utils import assert_array_almost_equal
-
-from himalaya.ridge import Ridge
-from himalaya.ridge import RidgeCV
-from himalaya.ridge import GroupRidgeCV
-from himalaya.ridge import solve_group_ridge_random_search
 
 
 def _create_dataset(backend):
@@ -146,13 +141,15 @@ class Ridge_(Ridge):
 
     def predict(self, X):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.validation import check_array
         from himalaya.scoring import r2_score
+        from himalaya.validation import check_array
         backend = get_backend()
 
+        X, y = validate_data(self, X, y, reset=False)
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 
@@ -176,13 +173,15 @@ class RidgeCV_(RidgeCV):
 
     def predict(self, X):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X))
 
     def score(self, X, y):
-        from himalaya.validation import check_array
         from himalaya.scoring import r2_score
+        from himalaya.validation import check_array
         backend = get_backend()
 
+        X, y = validate_data(self, X, y, reset=False)
         y_pred = super().predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 
@@ -214,10 +213,12 @@ class GroupRidgeCV_(GroupRidgeCV):
 
     def predict(self, X, split=False):
         backend = get_backend()
+        X = validate_data(self, X, reset=False)
         return backend.to_numpy(super().predict(X, split=split))
 
     def score(self, X, y, split=False):
         backend = get_backend()
+        X, y = validate_data(self, X, y, reset=False)
         return backend.to_numpy(super().score(X, y, split=split))
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+
 from setuptools import find_packages, setup
 
 # get version from himalaya/__init__.py
@@ -18,6 +19,7 @@ long_description = (this_directory / "README.rst").read_text()
 requirements = [
     "numpy",
     "scikit-learn",
+    "sklearn-compat"  # for backward compatibility
     # "cupy",  # optional backend
     # "torch",  # optional backend, 1.9+ preferred
     # "matplotlib",  # for visualization only

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ long_description = (this_directory / "README.rst").read_text()
 requirements = [
     "numpy",
     "scikit-learn",
-    "sklearn-compat"  # for backward compatibility
+    "packaging",  # for version parsing in sklearn compatibility
     # "cupy",  # optional backend
     # "torch",  # optional backend, 1.9+ preferred
     # "matplotlib",  # for visualization only


### PR DESCRIPTION
This is taking longer than expected...sklearn 1.6 added a bunch more checks on estimators, and they need to be fixed accordingly.

I added an extra (small) dependency on sklearn-compat to facilitate backward compatibility.

Currently fixed:
- [x] Ridge
- [ ] KernelRidge
- [ ] Lasso