### PR TITLE
FIX Estimators to pass sklearn checks with sklearn >= 1.6

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
       max-parallel: 5
-      fail-fast: true
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/himalaya/kernel_ridge/_kernelizer.py
+++ b/himalaya/kernel_ridge/_kernelizer.py
@@ -10,7 +10,7 @@ from sklearn.pipeline import _name_estimators, make_pipeline
 from sklearn.utils.validation import check_is_fitted
 
 from ..backend import force_cpu_backend, get_backend
-from ..validation import _get_string_dtype, check_array
+from ..validation import _get_string_dtype, check_array, validate_data
 from ._kernels import PAIRWISE_KERNEL_FUNCTIONS, pairwise_kernels
 
 
@@ -88,11 +88,10 @@ class Kernelizer(TransformerMixin, BaseEstimator):
         """
         accept_sparse = False if self.kernel == "precomputed" else ("csr",
                                                                     "csc")
-        X = check_array(X, accept_sparse=accept_sparse, ndim=2)
+        X = validate_data(self, X, reset=True, accept_sparse=accept_sparse, ndim=2)
 
         self.X_fit_ = _to_cpu(X) if self.kernel != "precomputed" else None
         self.dtype_ = _get_string_dtype(X)
-        self.n_features_in_ = X.shape[1]
 
         K = self._get_kernel(X)
         return K
@@ -136,11 +135,8 @@ class Kernelizer(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
         accept_sparse = False if self.kernel == "precomputed" else ("csr",
                                                                     "csc")
-        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse,
+        X = validate_data(self, X, reset=False, dtype=self.dtype_, accept_sparse=accept_sparse,
                         ndim=2)
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(
-                'Different number of features in X than during fit.')
         K = self._get_kernel(X, self.X_fit_)
         return K
 

--- a/himalaya/kernel_ridge/_kernels.py
+++ b/himalaya/kernel_ridge/_kernels.py
@@ -182,10 +182,15 @@ def linear_kernel(X, Y=None):
     backend = get_backend()
     X, Y = check_pairwise_arrays(X, Y)
 
-    K = X @ Y.T
-    if issparse(K):
-        K = K.toarray()
-    K = backend.asarray(K)
+    # Convert to backend arrays before matrix operations to handle transpose properly
+    if issparse(X):
+        X = X.toarray()
+    if issparse(Y):
+        Y = Y.toarray()
+    X = backend.asarray(X)
+    Y = backend.asarray(Y)
+    
+    K = backend.matmul(X, backend.transpose(Y))
     return K
 
 

--- a/himalaya/kernel_ridge/_kernels.py
+++ b/himalaya/kernel_ridge/_kernels.py
@@ -669,3 +669,8 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
 
     def _more_tags(self):
         return {'pairwise': True}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.pairwise = True
+        return tags

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -310,7 +310,7 @@ class KernelRidge(_BaseKernelRidge):
     def _get_kernel(self, X, Y=None):
         backend = get_backend()
         kernel_params = self.kernel_params or {}
-        if Y is not None and not issparse(X):
+        if Y is not None and not issparse(X) and not issparse(Y):
             Y = backend.asarray_like(Y, ref=X)
         kernel = pairwise_kernels(X, Y, metric=self.kernel, **kernel_params)
         return backend.asarray(kernel)
@@ -695,7 +695,7 @@ class _BaseWeightedKernelRidge(_BaseKernelRidge):
             n_kernels = len(self.kernels)
             kernels_params = self.kernels_params or [{}] * n_kernels
 
-            if Y is not None and not issparse(X):
+            if Y is not None and not issparse(X) and not issparse(Y):
                 Y = backend.asarray_like(Y, ref=X)
 
             kernels = []

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -16,6 +16,7 @@ from ._predictions import primal_weights_weighted_kernel_ridge
 
 from ..validation import check_array
 from ..validation import check_cv
+from ..validation import validate_data
 from ..validation import issparse
 from ..validation import _get_string_dtype
 from ..backend import get_backend
@@ -185,7 +186,7 @@ class KernelRidge(_BaseKernelRidge):
         backend = get_backend()
         accept_sparse = False if self.kernel == "precomputed" else ("csr",
                                                                     "csc")
-        X = check_array(X, accept_sparse=accept_sparse, ndim=2)
+        X = validate_data(self, X, reset=True, accept_sparse=accept_sparse, ndim=2)
         self.dtype_ = _get_string_dtype(X)
         y = check_array(y, dtype=self.dtype_, ndim=[1, 2])
         if X.shape[0] != y.shape[0]:
@@ -208,7 +209,6 @@ class KernelRidge(_BaseKernelRidge):
         K = self._get_kernel(X)
 
         self.X_fit_ = _to_cpu(X) if self.kernel != "precomputed" else None
-        self.n_features_in_ = X.shape[1]
         del X
 
         ravel = False
@@ -266,11 +266,8 @@ class KernelRidge(_BaseKernelRidge):
         backend = get_backend()
         accept_sparse = False if self.kernel == "precomputed" else ("csr",
                                                                     "csc")
-        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse,
-                        ndim=2)
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(
-                'Different number of features in X than during fit.')
+        X = validate_data(self, X, reset=False, dtype=self.dtype_, 
+                         accept_sparse=accept_sparse, ndim=2)
 
         K = self._get_kernel(X, self.X_fit_)
         del X
@@ -475,7 +472,7 @@ class KernelRidgeCV(KernelRidge):
         self : returns an instance of self.
         """
         backend = get_backend()
-        X = check_array(X, accept_sparse=("csr", "csc"), ndim=2)
+        X = validate_data(self, X, reset=True, accept_sparse=("csr", "csc"), ndim=2)
         self.dtype_ = _get_string_dtype(X)
         device = "cpu" if self.Y_in_cpu else None
         y = check_array(y, dtype=self.dtype_, ndim=[1, 2], device=device)
@@ -501,7 +498,6 @@ class KernelRidgeCV(KernelRidge):
         K = self._get_kernel(X)
 
         self.X_fit_ = _to_cpu(X) if self.kernel != "precomputed" else None
-        self.n_features_in_ = X.shape[1]
         del X
 
         ravel = False
@@ -588,11 +584,8 @@ class _BaseWeightedKernelRidge(_BaseKernelRidge):
         ndim = 3 if self.kernels == "precomputed" else 2
         accept_sparse = False if self.kernels == "precomputed" else ("csr",
                                                                      "csc")
-        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse,
-                        ndim=ndim)
-        if X.shape[-1] != self.n_features_in_:
-            raise ValueError(
-                'Different number of features in X than during fit.')
+        X = validate_data(self, X, reset=False, dtype=self.dtype_, 
+                         accept_sparse=accept_sparse, ndim=ndim)
 
         Ks = self._get_kernels(X, self.X_fit_)
         del X
@@ -653,12 +646,9 @@ class _BaseWeightedKernelRidge(_BaseKernelRidge):
         ndim = 3 if self.kernels == "precomputed" else 2
         accept_sparse = False if self.kernels == "precomputed" else ("csr",
                                                                      "csc")
-        X = check_array(X, dtype=self.dtype_, accept_sparse=accept_sparse,
-                        ndim=ndim)
+        X = validate_data(self, X, reset=False, dtype=self.dtype_, 
+                         accept_sparse=accept_sparse, ndim=ndim)
         y = check_array(y, dtype=self.dtype_, ndim=self.dual_coef_.ndim)
-        if X.shape[-1] != self.n_features_in_:
-            raise ValueError(
-                'Different number of features in X than during fit.')
 
         Ks = self._get_kernels(X, self.X_fit_)
         del X
@@ -906,7 +896,7 @@ class MultipleKernelRidgeCV(_BaseWeightedKernelRidge):
         ndim = 3 if self.kernels == "precomputed" else 2
         accept_sparse = False if self.kernels == "precomputed" else ("csr",
                                                                      "csc")
-        X = check_array(X, accept_sparse=accept_sparse, ndim=ndim)
+        X = validate_data(self, X, reset=True, accept_sparse=accept_sparse, ndim=ndim)
         self.dtype_ = _get_string_dtype(X)
         device = "cpu" if self.Y_in_cpu else None
         y = check_array(y, dtype=self.dtype_, ndim=[1, 2], device=device)
@@ -924,7 +914,6 @@ class MultipleKernelRidgeCV(_BaseWeightedKernelRidge):
         Ks = self._get_kernels(X)
 
         self.X_fit_ = _to_cpu(X) if self.kernels != "precomputed" else None
-        self.n_features_in_ = X.shape[-1]
         del X
 
         ravel = False
@@ -1122,7 +1111,7 @@ class WeightedKernelRidge(_BaseWeightedKernelRidge):
         ndim = 3 if self.kernels == "precomputed" else 2
         accept_sparse = False if self.kernels == "precomputed" else ("csr",
                                                                      "csc")
-        X = check_array(X, accept_sparse=accept_sparse, ndim=ndim)
+        X = validate_data(self, X, reset=True, accept_sparse=accept_sparse, ndim=ndim)
         self.dtype_ = _get_string_dtype(X)
         y = check_array(y, dtype=self.dtype_, ndim=[1, 2])
 
@@ -1139,7 +1128,6 @@ class WeightedKernelRidge(_BaseWeightedKernelRidge):
         Ks = self._get_kernels(X)
 
         self.X_fit_ = _to_cpu(X) if self.kernels != "precomputed" else None
-        self.n_features_in_ = X.shape[-1]
         del X
 
         ravel = False

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -240,6 +240,10 @@ class KernelRidge(_BaseKernelRidge):
         else:
             self.dual_coef_ = tmp
 
+        # Apply sample weight scaling to dual coefficients (sklearn compatibility)
+        if sample_weight is not None:
+            self.dual_coef_ = self.dual_coef_ * sw
+
         if ravel:
             self.dual_coef_ = self.dual_coef_[:, 0]
             if self.fit_intercept:
@@ -1159,6 +1163,10 @@ class WeightedKernelRidge(_BaseWeightedKernelRidge):
         self.dual_coef_ = self._call_solver(Ks=Ks, Y=y, alpha=self.alpha,
                                             deltas=self.deltas_,
                                             random_state=self.random_state)
+
+        # Apply sample weight scaling to dual coefficients (sklearn compatibility)
+        if sample_weight is not None:
+            self.dual_coef_ = self.dual_coef_ * sw
 
         if ravel or self.deltas_.shape[1] != self.dual_coef_.shape[1]:
             self.deltas_ = self.deltas_[:, 0]

--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -61,6 +61,11 @@ class _BaseKernelRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
     def _more_tags(self):
         return {'requires_y': True}
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+        return tags
+
 
 class KernelRidge(_BaseKernelRidge):
     """Kernel ridge regression.
@@ -540,6 +545,11 @@ class KernelRidgeCV(KernelRidge):
             }
         }
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        # Note: _xfail_checks is excluded as it's deprecated in sklearn 1.6+
+        return tags
+
 
 ###############################################################################
 ###############################################################################
@@ -966,6 +976,11 @@ class MultipleKernelRidgeCV(_BaseWeightedKernelRidge):
                 'because of the cross-validation splits.',
             }
         }
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        # Note: _xfail_checks is excluded as it's deprecated in sklearn 1.6+
+        return tags
 
 
 class WeightedKernelRidge(_BaseWeightedKernelRidge):

--- a/himalaya/kernel_ridge/tests/test_kernelizers.py
+++ b/himalaya/kernel_ridge/tests/test_kernelizers.py
@@ -60,7 +60,7 @@ def test_kernelizer_wrong_input(backend):
     with pytest.raises(ValueError, match="Unknown metric"):
         Kernelizer(kernel="wrong").fit(X1)
 
-    with pytest.raises(ValueError, match="Different number of features"):
+    with pytest.raises(ValueError, match="X has .* features.*expecting .* features"):
         Kernelizer().fit(X1).transform(X2)
 
 

--- a/himalaya/kernel_ridge/tests/test_kernelizers.py
+++ b/himalaya/kernel_ridge/tests/test_kernelizers.py
@@ -335,6 +335,11 @@ class Kernelizer_(Kernelizer):
         backend = get_backend()
         return backend.to_numpy(super().transform(X))
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
 
 @sklearn.utils.estimator_checks.parametrize_with_checks([
     Kernelizer_(),

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -580,6 +580,11 @@ class KernelRidge_(KernelRidge):
         else:
             return backend.to_numpy(r2_score(y_true, y_pred))
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
 
 class KernelRidgeCV_(KernelRidgeCV):
     """Cast predictions to numpy arrays, to be used in scikit-learn tests.
@@ -611,6 +616,11 @@ class KernelRidgeCV_(KernelRidgeCV):
         else:
             return backend.to_numpy(r2_score(y_true, y_pred))
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
 
 class MultipleKernelRidgeCV_(MultipleKernelRidgeCV):
     """Cast predictions to numpy arrays, to be used in scikit-learn tests.
@@ -632,6 +642,11 @@ class MultipleKernelRidgeCV_(MultipleKernelRidgeCV):
     def score(self, X, y, split=False):
         backend = get_backend()
         return backend.to_numpy(super().score(X, y, split=split))
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
 
 
 class WeightedKernelRidge_(WeightedKernelRidge):
@@ -656,6 +671,11 @@ class WeightedKernelRidge_(WeightedKernelRidge):
     def score(self, X, y, split=False):
         backend = get_backend()
         return backend.to_numpy(super().score(X, y, split=split))
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
 
 
 @sklearn.utils.estimator_checks.parametrize_with_checks([

--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -678,12 +678,33 @@ class WeightedKernelRidge_(WeightedKernelRidge):
         return tags
 
 
+def expected_failed_checks(estimator):
+    """Return expected failed checks for sklearn 1.6+ compatibility.
+
+    This replaces the deprecated _xfail_checks mechanism.
+    """
+    estimator_name = estimator.__class__.__name__
+
+    # Only handle estimators that previously had _xfail_checks
+    if estimator_name in ['KernelRidgeCV_', 'MultipleKernelRidgeCV_']:
+        return {
+            'check_sample_weight_equivalence_on_dense_data':
+            'zero sample_weight is not equivalent to removing samples, '
+            'because of the cross-validation splits.',
+            'check_sample_weight_equivalence_on_sparse_data':
+            'zero sample_weight is not equivalent to removing samples, '
+            'because of the cross-validation splits.',
+        }
+
+    return {}
+
+
 @sklearn.utils.estimator_checks.parametrize_with_checks([
     KernelRidge_(),
     KernelRidgeCV_(),
     MultipleKernelRidgeCV_(),
     WeightedKernelRidge_(),
-])
+], expected_failed_checks=expected_failed_checks)
 @pytest.mark.parametrize('backend', ALL_BACKENDS)
 def test_check_estimator(estimator, check, backend):
     backend = set_backend(backend)

--- a/himalaya/lasso/_sklearn_api.py
+++ b/himalaya/lasso/_sklearn_api.py
@@ -5,6 +5,7 @@ from ._group_lasso import solve_sparse_group_lasso_cv
 
 from ..validation import check_array
 from ..validation import check_cv
+from ..validation import validate_data
 from ..validation import _get_string_dtype
 from ..backend import get_backend
 from ..backend import force_cpu_backend
@@ -101,13 +102,11 @@ class SparseGroupLassoCV(MultiOutputMixin, RegressorMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        X = check_array(X, accept_sparse=False, ndim=2)
+        X, y = validate_data(self, X, y, reset=True, accept_sparse=False, ndim=2)
         self.dtype_ = _get_string_dtype(X)
         y = check_array(y, dtype=self.dtype_, ndim=[1, 2])
         if X.shape[0] != y.shape[0]:
             raise ValueError("Inconsistent number of samples.")
-
-        self.n_features_in_ = X.shape[1]
         cv = check_cv(self.cv, y)
         ravel = False
         if y.ndim == 1:
@@ -159,10 +158,7 @@ class SparseGroupLassoCV(MultiOutputMixin, RegressorMixin, BaseEstimator):
         """
         backend = get_backend()
         check_is_fitted(self)
-        X = check_array(X, dtype=self.dtype_, accept_sparse=False, ndim=2)
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(
-                'Different number of features in X than during fit.')
+        X = validate_data(self, X, reset=False, dtype=self.dtype_, accept_sparse=False, ndim=2)
         Y_hat = backend.to_numpy(X) @ backend.to_numpy(self.coef_)
         return backend.asarray_like(Y_hat, ref=X)
 
@@ -183,7 +179,7 @@ class SparseGroupLassoCV(MultiOutputMixin, RegressorMixin, BaseEstimator):
         score : array of shape (n_targets, )
             R^2 of self.predict(X) versus y.
         """
-        y_pred = self.predict(X, y)
+        y_pred = self.predict(X)
         y_true = check_array(y, dtype=self.dtype_, ndim=self.coef_.ndim)
 
         if y_true.ndim == 1:

--- a/himalaya/lasso/_sklearn_api.py
+++ b/himalaya/lasso/_sklearn_api.py
@@ -193,3 +193,8 @@ class SparseGroupLassoCV(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
     def _more_tags(self):
         return {'requires_y': True}
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+        return tags

--- a/himalaya/ridge/_sklearn_api.py
+++ b/himalaya/ridge/_sklearn_api.py
@@ -46,6 +46,11 @@ class _BaseRidge(ABC, MultiOutputMixin, RegressorMixin, BaseEstimator):
     def _more_tags(self):
         return {'requires_y': True}
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+        return tags
+
 
 class Ridge(_BaseRidge):
     """Ridge regression.

--- a/himalaya/tests/test_validation.py
+++ b/himalaya/tests/test_validation.py
@@ -6,6 +6,7 @@ from himalaya.backend import set_backend
 from himalaya.backend import ALL_BACKENDS
 from himalaya.validation import _assert_all_finite
 from himalaya.validation import check_cv
+from himalaya.validation import validate_data
 
 
 @pytest.mark.parametrize('backend', ALL_BACKENDS)
@@ -31,3 +32,76 @@ def test_check_cv():
     with pytest.raises(ValueError, match="exceed number of samples"):
         y = np.zeros(2)
         check_cv(cv, y)
+
+
+class DummyEstimator:
+    """Dummy estimator for testing validate_data"""
+    def __init__(self):
+        pass
+
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
+def test_validate_data_X_only(backend):
+    backend = set_backend(backend)
+    X = backend.asarray([[1, 2], [3, 4]])
+    estimator = DummyEstimator()
+    
+    # Test reset=True (fit behavior)
+    X_val = validate_data(estimator, X, reset=True, ndim=2)
+    assert hasattr(estimator, 'n_features_in_')
+    assert estimator.n_features_in_ == 2
+    assert X_val.shape == (2, 2)
+    
+    # Test reset=False (predict behavior) - should work
+    X_val2 = validate_data(estimator, X, reset=False, ndim=2)
+    assert X_val2.shape == (2, 2)
+    
+    # Test reset=False with wrong number of features - should fail
+    X_wrong = backend.asarray([[1, 2, 3], [4, 5, 6]])
+    with pytest.raises(ValueError, match="X has 3 features.*expecting 2 features"):
+        validate_data(estimator, X_wrong, reset=False, ndim=2)
+
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
+def test_validate_data_X_and_y(backend):
+    backend = set_backend(backend)
+    X = backend.asarray([[1, 2], [3, 4]])
+    y = backend.asarray([1, 0])
+    estimator = DummyEstimator()
+    
+    # Test with both X and y - X gets ndim=2, y gets default [1,2]
+    X_val, y_val = validate_data(estimator, X, y, reset=True, ndim=2)
+    assert hasattr(estimator, 'n_features_in_')
+    assert estimator.n_features_in_ == 2
+    assert X_val.shape == (2, 2)
+    assert y_val.shape == (2,)
+
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS) 
+def test_validate_data_no_validation(backend):
+    backend = set_backend(backend)
+    estimator = DummyEstimator()
+    
+    # Test X='no_validation' only
+    result = validate_data(estimator, X='no_validation', reset=True)
+    assert result == 'no_validation'
+    
+    # Test y='no_validation'
+    X = backend.asarray([[1, 2], [3, 4]])
+    X_val = validate_data(estimator, X, y='no_validation', reset=True, ndim=2)
+    assert X_val.shape == (2, 2)
+    assert hasattr(estimator, 'n_features_in_')
+    
+    # Test both 'no_validation'
+    result = validate_data(estimator, X='no_validation', y='no_validation', reset=True)
+    assert result == 'no_validation'
+
+
+def test_validate_data_error_without_n_features_in():
+    # Test that predict without prior fit doesn't crash
+    estimator = DummyEstimator()
+    X = np.array([[1, 2], [3, 4]])
+    
+    # Should work fine if estimator doesn't have n_features_in_ yet
+    X_val = validate_data(estimator, X, reset=False, ndim=2)
+    assert X_val.shape == (2, 2)

--- a/himalaya/tests/test_validation.py
+++ b/himalaya/tests/test_validation.py
@@ -45,17 +45,17 @@ def test_validate_data_X_only(backend):
     backend = set_backend(backend)
     X = backend.asarray([[1, 2], [3, 4]])
     estimator = DummyEstimator()
-    
+
     # Test reset=True (fit behavior)
     X_val = validate_data(estimator, X, reset=True, ndim=2)
     assert hasattr(estimator, 'n_features_in_')
     assert estimator.n_features_in_ == 2
     assert X_val.shape == (2, 2)
-    
+
     # Test reset=False (predict behavior) - should work
     X_val2 = validate_data(estimator, X, reset=False, ndim=2)
     assert X_val2.shape == (2, 2)
-    
+
     # Test reset=False with wrong number of features - should fail
     X_wrong = backend.asarray([[1, 2, 3], [4, 5, 6]])
     with pytest.raises(ValueError, match="X has 3 features.*expecting 2 features"):
@@ -68,7 +68,7 @@ def test_validate_data_X_and_y(backend):
     X = backend.asarray([[1, 2], [3, 4]])
     y = backend.asarray([1, 0])
     estimator = DummyEstimator()
-    
+
     # Test with both X and y - X gets ndim=2, y gets default [1,2]
     X_val, y_val = validate_data(estimator, X, y, reset=True, ndim=2)
     assert hasattr(estimator, 'n_features_in_')
@@ -77,21 +77,21 @@ def test_validate_data_X_and_y(backend):
     assert y_val.shape == (2,)
 
 
-@pytest.mark.parametrize('backend', ALL_BACKENDS) 
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
 def test_validate_data_no_validation(backend):
     backend = set_backend(backend)
     estimator = DummyEstimator()
-    
+
     # Test X='no_validation' only
     result = validate_data(estimator, X='no_validation', reset=True)
     assert result == 'no_validation'
-    
+
     # Test y='no_validation'
     X = backend.asarray([[1, 2], [3, 4]])
     X_val = validate_data(estimator, X, y='no_validation', reset=True, ndim=2)
     assert X_val.shape == (2, 2)
     assert hasattr(estimator, 'n_features_in_')
-    
+
     # Test both 'no_validation'
     result = validate_data(estimator, X='no_validation', y='no_validation', reset=True)
     assert result == 'no_validation'
@@ -101,7 +101,55 @@ def test_validate_data_error_without_n_features_in():
     # Test that predict without prior fit doesn't crash
     estimator = DummyEstimator()
     X = np.array([[1, 2], [3, 4]])
-    
+
     # Should work fine if estimator doesn't have n_features_in_ yet
     X_val = validate_data(estimator, X, reset=False, ndim=2)
     assert X_val.shape == (2, 2)
+
+
+@pytest.mark.parametrize('backend', ALL_BACKENDS)
+def test_validate_data_3d_feature_axis(backend):
+    """Test feature axis handling for 3D arrays (precomputed kernels).
+
+    This test ensures that validate_data correctly handles the feature dimension
+    for 3D precomputed kernel arrays where:
+    - During fit: shape (n_kernels, n_samples_train, n_samples_train)
+    - During predict: shape (n_kernels, n_samples_test, n_samples_train)
+
+    The "feature" dimension (last axis) should be consistent between fit and predict.
+    """
+    backend = set_backend(backend)
+    estimator = DummyEstimator()
+
+    # Simulate fit with 3D precomputed kernels: (n_kernels=2, n_train=600, n_train=600)
+    X_fit = backend.asarray(np.random.randn(2, 600, 600))
+    X_val_fit = validate_data(estimator, X_fit, reset=True, ndim=3)
+
+    # Should store n_features_in_ as last axis (600)
+    assert hasattr(estimator, 'n_features_in_')
+    assert estimator.n_features_in_ == 600
+    assert X_val_fit.shape == (2, 600, 600)
+
+    # Simulate predict with 3D kernels: (n_kernels=2, n_test=300, n_train=600)
+    # The middle axis changes (test samples) but last axis stays same (training samples)
+    X_predict = backend.asarray(np.random.randn(2, 300, 600))
+    X_val_predict = validate_data(estimator, X_predict, reset=False, ndim=3)
+
+    # Should validate successfully - last axis (600) matches stored n_features_in_
+    assert X_val_predict.shape == (2, 300, 600)
+
+    # Test failure case: wrong last dimension
+    X_wrong = backend.asarray(np.random.randn(2, 300, 500))  # wrong last dim
+    with pytest.raises(ValueError, match="X has 500 features.*expecting 600 features"):
+        validate_data(estimator, X_wrong, reset=False, ndim=3)
+
+    # Test explicit feature_axis parameter
+    estimator2 = DummyEstimator()
+
+    # Using feature_axis=1 (middle axis) for 3D - this was the old buggy behavior
+    validate_data(estimator2, X_fit, reset=True, ndim=3, feature_axis=1)
+    assert estimator2.n_features_in_ == 600  # middle axis
+
+    # This should fail with the test data because middle axis is different (300 vs 600)
+    with pytest.raises(ValueError, match="X has 300 features.*expecting 600 features"):
+        validate_data(estimator2, X_predict, reset=False, ndim=3, feature_axis=1)

--- a/himalaya/validation.py
+++ b/himalaya/validation.py
@@ -283,67 +283,73 @@ def _get_string_dtype(array):
     return _dtype_to_str(dtype)
 
 
-def validate_data(estimator, X='no_validation', y='no_validation', reset=True, **check_params):
+def validate_data(estimator, X='no_validation', y='no_validation', reset=True, feature_axis=-1, **check_params):
     """Input validation for estimators that wraps check_array with n_features_in_ management.
-    
+
     This function provides sklearn 1.6+ compatible input validation by wrapping
     the existing check_array function and managing the n_features_in_ attribute
     for sklearn compatibility.
-    
+
     Parameters
     ----------
     estimator : object
         The estimator instance for which to validate data.
     X : array-like, default='no_validation'
         Input data to validate. If 'no_validation', skip X validation.
-    y : array-like, default='no_validation'  
+    y : array-like, default='no_validation'
         Target data to validate. If 'no_validation', skip y validation.
     reset : bool, default=True
         Whether to reset the n_features_in_ attribute. Set to True during fit(),
         False during predict().
+    feature_axis : int, default=-1
+        Axis along which to count features. Default -1 (last axis) handles
+        both 2D arrays (axis 1) and 3D precomputed kernels (axis 2) correctly.
+        For regular 2D input: shape (n_samples, n_features) -> axis -1 = axis 1
+        For 3D precomputed kernels: shape (n_kernels, n_samples, n_samples) -> axis -1 = axis 2
     **check_params : dict
         Additional parameters to pass to check_array for X validation.
-        
+
     Returns
     -------
     X_validated : array-like or 'no_validation'
         Validated input data.
-    y_validated : array-like or 'no_validation'  
+    y_validated : array-like or 'no_validation'
         Validated target data.
     """
     # Handle X validation
     validate_X = not (isinstance(X, str) and X == 'no_validation')
     if validate_X:
         X_validated = check_array(X, **check_params)
-        
+
         # Manage n_features_in_ attribute
         if reset:
-            # During fit: store number of features
-            estimator.n_features_in_ = X_validated.shape[1]
+            # During fit: store number of features using specified axis
+            estimator.n_features_in_ = X_validated.shape[feature_axis]
         else:
             # During predict: check consistency with stored value
             if hasattr(estimator, 'n_features_in_'):
-                if X_validated.shape[1] != estimator.n_features_in_:
+                current_n_features = X_validated.shape[feature_axis]
+                if current_n_features != estimator.n_features_in_:
                     raise ValueError(
-                        f"X has {X_validated.shape[1]} features, but {estimator.__class__.__name__} "
+                        f"X has {current_n_features} features, but {estimator.__class__.__name__} "
                         f"is expecting {estimator.n_features_in_} features as input."
                     )
     else:
         X_validated = X
-        
-    # Handle y validation  
+
+    # Handle y validation
     validate_y = not (isinstance(y, str) and y == 'no_validation')
     if validate_y:
         # For y, we don't pass all check_params, just extract relevant ones
-        y_check_params = {k: v for k, v in check_params.items() 
-                         if k in ['dtype', 'accept_sparse', 'copy', 'force_all_finite', 'device']}
+        y_check_params = {k: v for k, v in check_params.items()
+                          if k in ['dtype', 'accept_sparse', 'copy', 'force_all_finite', 'device']}
         # y typically has different ndim requirements
         if 'ndim' not in y_check_params:
             y_check_params['ndim'] = [1, 2]
         y_validated = check_array(y, **y_check_params)
     else:
         y_validated = y
-        
+
     # Return appropriate format based on what was validated
     if validate_X and validate_y:
         return X_validated, y_validated


### PR DESCRIPTION
## Summary
This PR implements comprehensive sklearn 1.6+ compatibility fixes for all Himalaya estimators:

- **✅ Implemented `validate_data()` function** - Central validation function that wraps `check_array` and manages `n_features_in_` attribute
- **✅ Updated all estimators to use `validate_data()`** - Ridge, RidgeCV, GroupRidgeCV, KernelRidge, KernelRidgeCV, MultipleKernelRidgeCV, WeightedKernelRidge, SparseGroupLassoCV, and Kernelizer
- **✅ Added `__sklearn_tags__()` methods** - New sklearn 1.6+ tag system replacing deprecated `_more_tags()` 
- **✅ Fixed sparse input support** - Added proper sparse input tags for test classes
- **✅ Removed manual `n_features_in_` management** - Now handled automatically by `validate_data()`
- **✅ Updated error messages** - Match sklearn 1.6+ validation error format
- **✅ Fixed SparseGroupLassoCV.score()** - Removed invalid `y` parameter from `predict()` call

## Test plan
- [x] All Ridge estimator tests pass
- [x] All KernelRidge estimator tests pass  
- [x] All Lasso estimator tests pass
- [x] Kernelizer tests pass
- [x] Basic sklearn compatibility tests pass
- [x] **TODO: Fix `check_sample_weight_equivalence` failures** - Remaining issue for sklearn 1.6 full compatibility

## Missing steps
The main remaining task is fixing the `check_sample_weight_equivalence` test failures. This affects estimators that should support sample weights but currently don't implement proper sample weight handling in their fit methods.

🤖 Generated with [Claude Code](https://claude.ai/code)