### PR TITLE
FIX cupy.is_in_gpu for numpy >= 2.0

### DIFF
--- a/himalaya/backend/cupy.py
+++ b/himalaya/backend/cupy.py
@@ -165,7 +165,7 @@ def to_gpu(array, device=None):
 
 
 def is_in_gpu(array):
-    return getattr(array, "device", None) is not None
+    return getattr(array, "device", 'cpu') != 'cpu'
 
 
 def asarray(a, dtype=None, order=None, device=None):


### PR DESCRIPTION
All tests in `himalaya/kernel_ridge/tests/test_force_cpu.py` were failing for the cupy backend when `force_cpu=True`.

NumPy 2.0 added compliance with the Array API, which means a `.device` property for all `ndarray`s that's always equal to `'cpu'`. Previously, himalaya assumed that the property did not exist when checking the device. I tested this PR locally, and it works for both NumPy >=2.0 and 1.26.4 (the last pre-2.0 release).