### PR TITLE
TST Fix CI: mark check_all_zero_sample_weights_error as expected failure

### DIFF
--- a/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
+++ b/himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py
@@ -686,18 +686,28 @@ def expected_failed_checks(estimator):
     """
     estimator_name = estimator.__class__.__name__
 
-    # Only handle estimators that previously had _xfail_checks
+    # himalaya intentionally allows fitting with all-zero sample weights
+    # (see test_kernel_ridge_sample_weight_basic) instead of raising the
+    # ValueError that scikit-learn's check_all_zero_sample_weights_error
+    # expects.
+    checks = {
+        'check_all_zero_sample_weights_error':
+        'himalaya allows fitting with all-zero sample weights instead of '
+        'raising a ValueError.',
+    }
+
+    # The cross-validation estimators previously had _xfail_checks
     if estimator_name in ['KernelRidgeCV_', 'MultipleKernelRidgeCV_']:
-        return {
+        checks.update({
             'check_sample_weight_equivalence_on_dense_data':
             'zero sample_weight is not equivalent to removing samples, '
             'because of the cross-validation splits.',
             'check_sample_weight_equivalence_on_sparse_data':
             'zero sample_weight is not equivalent to removing samples, '
             'because of the cross-validation splits.',
-        }
+        })
 
-    return {}
+    return checks
 
 
 # Handle sklearn version compatibility for expected_failed_checks parameter


### PR DESCRIPTION
## Summary

The `run-tests` jobs on Python 3.11 and 3.12 (e.g. on #100) fail with 8 errors, all of the form:

```
FAILED .../test_sklearn_api_kernel.py::test_check_estimator[...-check_all_zero_sample_weights_error]
  - AssertionError: Did not raise: [<class 'ValueError'>]
```

These failures are **unrelated to the codecov-action bump in #100** — they are pre-existing on `main` and only surface on Python 3.11/3.12 because those jobs install a newer scikit-learn (≥1.6) that added the `check_all_zero_sample_weights_error` estimator check.

That check expects `fit` to raise a `ValueError` when **all** sample weights are zero. himalaya **intentionally allows** fitting with all-zero sample weights — see `test_kernel_ridge_sample_weight_basic`, which explicitly asserts that this does not raise. So rather than changing estimator behavior, this marks the check as a documented expected failure via the existing `expected_failed_checks` mechanism (sklearn ≥1.6's replacement for `_xfail_checks`).

## Changes

- Extend `expected_failed_checks` in `test_sklearn_api_kernel.py` to mark `check_all_zero_sample_weights_error` as an expected failure for all four kernel estimators (`KernelRidge_`, `KernelRidgeCV_`, `MultipleKernelRidgeCV_`, `WeightedKernelRidge_`).

The ridge estimators don't need this — scikit-learn does not generate that check for them.

## Verification

Reproduced the 8 failures locally with scikit-learn 1.9.0, then confirmed they become clean `xfail`s after the change. The full numpy-backend `test_check_estimator` suite passes with no failures.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY8CxMAzjjxeRyX2bDs7Ap)_