### PR TITLE
FIX sklearn sample_weights checks for cupy and numpy<2

### DIFF
--- a/himalaya/kernel_ridge/_sklearn_api.py
+++ b/himalaya/kernel_ridge/_sklearn_api.py
@@ -244,7 +244,8 @@ class KernelRidge(_BaseKernelRidge):
         # Apply sample weight scaling to dual coefficients (sklearn compatibility)
         if sample_weight is not None:
             # Ensure sw is on the same device as dual_coef_
-            sw = backend.asarray(sw, device=self.dual_coef_.device if hasattr(self.dual_coef_, 'device') else None)
+            if not backend.is_in_gpu(self.dual_coef_):
+                sw = backend.to_cpu(sw)
             self.dual_coef_ = self.dual_coef_ * sw
 
         if ravel:
@@ -1173,7 +1174,8 @@ class WeightedKernelRidge(_BaseWeightedKernelRidge):
         # Apply sample weight scaling to dual coefficients (sklearn compatibility)
         if sample_weight is not None:
             # Ensure sw is on the same device as dual_coef_
-            sw = backend.asarray(sw, device=self.dual_coef_.device if hasattr(self.dual_coef_, 'device') else None)
+            if not backend.is_in_gpu(self.dual_coef_):
+                sw = backend.to_cpu(sw)
             self.dual_coef_ = self.dual_coef_ * sw
 
         if ravel or self.deltas_.shape[1] != self.dual_coef_.shape[1]:


### PR DESCRIPTION
This PR fixes the following failing tests:
```
FAILED himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py::test_check_estimator[cupy-KernelRidge_()-check_sample_weights_not_an_array] - TypeError: Unsupported type <class 'numpy.ndarray'>
FAILED himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py::test_check_estimator[cupy-KernelRidge_()-check_sample_weights_list] - TypeError: Unsupported type <class 'numpy.ndarray'>
FAILED himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py::test_check_estimator[cupy-KernelRidge_()-check_sample_weights_shape] - TypeError: Unsupported type <class 'numpy.ndarray'>
FAILED himalaya/kernel_ridge/tests/test_sklearn_api_kernel.py::test_check_estimator[cupy-KernelRidge_()-check_sample_weights_not_overwritten] - TypeError: Unsupported type <class 'numpy.ndarray'>
```
that had this traceback:
```
himalaya/kernel_ridge/_sklearn_api.py:248: in fit                                                                           
    sw = backend.asarray(sw, device=self.dual_coef_.device if hasattr(self.dual_coef_, 'device') else None)
    self.dual_coef_ = self.dual_coef_ * sw                                                                                  
cupy/_core/core.pyx:1799: in cupy._core.core._ndarray_base.__array_ufunc__                                                                                                                                                                              
    ???                                                                                                                                                                                                                                                 
cupy/_core/_kernel.pyx:1285: in cupy._core._kernel.ufunc.__call__                                                                                                                                                                                           ???                                                       
cupy/_core/_kernel.pyx:159: in cupy._core._kernel._preprocess_args                                                                                                                                                                                      
    ???                                                       
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                                       
                                                                                                                                                                                                                                                        >   ???                                                       
E   TypeError: Unsupported type <class 'numpy.ndarray'>
```
The device moving logic fails since `np.ndarray` doesn't support `.device` below version 2. This logic was introduced with the MPS backend, so we should probably test that backend before merging.

This was not an issue for `numpy>2`.